### PR TITLE
Rewrite 20260306_nms.nvlu Marp slides to match NMS/NVLU seminar content

### DIFF
--- a/20260306_nms.nvlu/20260306_nms.nvlu.md
+++ b/20260306_nms.nvlu/20260306_nms.nvlu.md
@@ -1,7 +1,7 @@
 ---
 marp: true
-theme:
-header: "2026/03/06 研究スキルアップセミナー 研究データを"見える化"するための情報探索とデータ可視化スキル"
+theme: default
+header: '2026/03/06 研究スキルアップセミナー 研究データを"見える化"するための情報探索とデータ可視化スキル'
 footer: 2026 ONO Hiromasa, CC-BY-4.0
 paginate: true
 
@@ -11,6 +11,7 @@ paginate: true
 ## Part 2. 研究データの可視化に役立つデータベース・ウェブツール
 
 ---
+
 小野 浩雅 ([Researchmap](https://researchmap.jp/hiromasaono))
 
 広島大学ゲノム編集イノベーションセンター バイオDX産学共創拠点 プロジェクトマネージャー
@@ -34,16 +35,20 @@ ono@pt-bio.com
 
 ---
  ![](https://raw.githubusercontent.com/hiromasaono/training/master/images/20240924_selfintro.jpg)
-  
+
 ---
 ## 自己紹介
-- 小野 浩雅 ([Researchmap](https://researchmap.jp/hiromasaono)) 
+- 小野 浩雅 ([Researchmap](https://researchmap.jp/hiromasaono))
   - [統合TV](https://togotv.dbcls.jp/)の運営・編集
   - [RefEx](https://refex.dbcls.jp/)の開発
     - 遺伝子発現解析の基準となる各遺伝子の遺伝子発現量を簡単に検索、閲覧できるウェブツール
   - 2024年4月から
     - [プラチナバイオ株式会社](https://www.pt-bio.com/) 事業推進部 ディレクター / 広島大学ゲノム編集イノベーションセンター バイオDX産学共創拠点 プロジェクトマネージャー
       - ゲノム解析(BioDX)とゲノム編集を活用して生物機能をデザインするデジタル育種を実現し、社会課題の解決を目指す
+
+---
+# Part 1. TogoTV を駆使して、生命科学研究のためのデータベースを探す・学ぶ・使う
+
 ---
 # 統合TV(TogoTV)
 ## 課題
@@ -55,7 +60,7 @@ ono@pt-bio.com
 - https://togotv.dbcls.jp/ 📺
   - [DBCLS](https://dbcls.rois.ac.jp/index.html)が運営する、生命科学分野における有用な **データベースやツールの動画マニュアル、講演や講習会動画、資料、イラスト** を独自に制作し、紹介するウェブサイト
     - 実験系研究者の初学者が主要な想定利用者
-    - 自主学習、新人･後輩指導、講義・勉強会の教材として
+    - 自主学習、新人・後輩指導、講義・勉強会の教材として
   - 2007年8月スタート
 ![bg right:40% 100%](https://raw.githubusercontent.com/hiromasaono/training/master/images/20240924_01.jpg)
 
@@ -67,8 +72,8 @@ ono@pt-bio.com
 ---
 # TogoTV@YouTube
 - 各動画は[YouTubeで公開](http://www.youtube.com/user/togotv/)されており、環境に応じた解像度、倍速表示等で快適に閲覧可能
-- 2,200本を超える動画が公開されており、のべ320万回 (月間3万回以上) 再生
-(2024年9月末現在)
+- 2,300本に迫る動画が公開されており、338万回以上 再生
+(2025年3月末現在)
 
 ![bg right:58% 100%](https://raw.githubusercontent.com/hiromasaono/training/master/images/20240924_TogoTVYouTube_stats_Ja.jpg)
 
@@ -122,19 +127,20 @@ ono@pt-bio.com
 - [ラボの新人がまずマスターしたいデータベース・ウェブツール \(2020年4月\)](https://togotv.dbcls.jp/course.html?id=PL0uaKHgcG00Z89qgyoEbSof6VSGVxpplc)
 - [文献の検索や管理、情報収集に役立つツール](https://togotv.dbcls.jp/course.html?id=PL5409971734873D19)
 - [文章の執筆に役立つツール](https://togotv.dbcls.jp/course.html?id=PL0uaKHgcG00Y4Nuo6g08Ql3CsCefTvB9H)
-- [塩基配列の検索、取得、比較を行う](https://togotv.dbcls.jp/course.html?id=PL0uaKHgcG00YVdf_SS5kpKH9uqrYQLqn7)- [ゲノムブラウザを使ってゲノム配列に関連する情報を検索・取得・可視化する](https://togotv.dbcls.jp/course.html?id=PL0uaKHgcG00bs1Yno9jCCLqVntyzVPqGT)
+- [塩基配列の検索、取得、比較を行う](https://togotv.dbcls.jp/course.html?id=PL0uaKHgcG00YVdf_SS5kpKH9uqrYQLqn7)
+- [ゲノムブラウザを使ってゲノム配列に関連する情報を検索・取得・可視化する](https://togotv.dbcls.jp/course.html?id=PL0uaKHgcG00bs1Yno9jCCLqVntyzVPqGT)
 - [公共の遺伝子発現データの検索や解析を行う](https://togotv.dbcls.jp/course.html?id=PL0uaKHgcG00YDVET14wC0-GhpI5l3y8T-)
 - [ウェブブラウザ上でRNA\-seqデータ解析をする](https://togotv.dbcls.jp/course.html?id=PL0uaKHgcG00ZUuDj3jxC8lYshLxxjqi-P)
 - [図表を作成する](https://togotv.dbcls.jp/course.html?id=PL0uaKHgcG00aFMd_yWI0xuzROpPWi7nSb)
 - [疾患に関連するバリアントや遺伝子発現の情報を調べる](https://togotv.dbcls.jp/course.html?id=PL0uaKHgcG00a1DeTTRteZSWzmpDTEImAK)
-- [バイオインフォマティクスツール･パッケージを自作する](https://togotv.dbcls.jp/course.html?id=PL0uaKHgcG00aJSa233gkhBA2HHe0-Ha-B)
+- [バイオインフォマティクスツール・パッケージを自作する](https://togotv.dbcls.jp/course.html?id=PL0uaKHgcG00aJSa233gkhBA2HHe0-Ha-B)
 
 
 
 ---
 # 講演・講習会
 - キーワードから、「講演」や「講習会」を簡単に検索可能
-- サービスの開発者･研究者が、背景や周辺の基礎知識を紹介するとともにDBやウェブツールの基本的な使いこなし術や高度な組み合わせ方法などを紹介
+- サービスの開発者・研究者が、背景や周辺の基礎知識を紹介するとともにDBやウェブツールの基本的な使いこなし術や高度な組み合わせ方法などを紹介
 - 講習会の復習や、他分野の研究内容を (何度でも繰り返し)学習することができます。
 ![bg right:50% 100%](https://raw.githubusercontent.com/hiromasaono/training/master/images/20240924_02.jpg)
 
@@ -176,10 +182,10 @@ ono@pt-bio.com
 
 ---
 # 学会との連携
-  - 日本人類遺伝学会の教育コンテンツ配信システム[JSHG-WebCast(JWC)](https://jshg.jp/webcast/webtools/) 
+  - 日本人類遺伝学会の教育コンテンツ配信システム[JSHG-WebCast(JWC)](https://jshg.jp/webcast/webtools/)
     - 統合TVと学会との連携は初めての試み
       - 統合TVで作成する動画について学会の推薦を受けた専門家のレビューを受けられる
-      - 分野の専門家自身の講義・講習をコンテンツ化できる 
+      - 分野の専門家自身の講義・講習をコンテンツ化できる
 ![bg right:40% 100%](https://raw.githubusercontent.com/hiromasaono/training/master/images/20221221_06.jpg)
   - 日本小児遺伝学会とも連携予定
 ---
@@ -203,7 +209,7 @@ ono@pt-bio.com
 
 ---
 # 日本分子生物学会との連携
-- 2023年の第46回日本分子生物学会年会(参加者8000人以上)の参加章シール企画に公式採用されました🙌
+- 2023年の第46回日本分子生物学会年会(参加者8000人以上)の参加章シール企画に公式採用されました
 - すべての素材はTogo picture galleryにあります
   - 当時なかったものは追加で制作
 ![bg right:40% 100%](https://raw.githubusercontent.com/hiromasaono/training/master/images/20231231_MBSJ_togopic.png)
@@ -221,7 +227,7 @@ ono@pt-bio.com
 - 動画やイラストを制作してくれる方を随時募集中です!
 - オンラインで完結する作成環境を整備しており、遠隔地でもOKです。
 - 「本業優先」でノルマ無し
-- 謝金あります💰️
+- 謝金あります
 - 動画制作の実際: [「画面録画/編集ソフトウェア Camtasia 2019 を使って統合TVの動画を作成する」](https://togotv.dbcls.jp/20200129.html)
 - 静止画制作の実際: [「ライフサイエンス分野のイラスト集を作る仕事@AJACS本郷8」](https://togotv.dbcls.jp/20110322.html)
 ![bg right:40% 85%](https://raw.githubusercontent.com/hiromasaono/training/master/images/20240114_03.jpg)
@@ -237,136 +243,341 @@ ono@pt-bio.com
 ![bg right:40% 70%](https://raw.githubusercontent.com/hiromasaono/training/master/images/20240924_DigitalTools4LS.jpg)
 
 ---
+# Part 1 まとめ
+- **統合TV（togotv.dbcls.jp）** を活用しよう
+  - 動画マニュアル：ツール・DBの使い方をゼロから学べる
+  - スキル別コース：目的に合った動画を体系的に視聴
+  - Togo picture gallery：CC-BY-4.0 のイラストを自由に使用
+  - リクエスト：欲しい動画・イラストをリクエスト可能
+- 生命科学分野の日々増加するデータベース・ツールを「動画マニュアル」を活用して効率よく使いこなそう
+
+---
 # Part 2. 研究データの可視化に役立つデータベース・ウェブツール
 
+---
+## 今日のゴール：「何を見たいか」からツールを選べるようになる
+
+| 目的 | ★☆☆ データを貼るだけ | ★★☆ リスト・設定あり | ★★★ 解析データが必要 |
+|:--|:--|:--|:--|
+| 📊 分布・統計を見たい | BoxPlotR | — | — |
+| 🔵 集合を比較したい | Venn Diagram / draw.io | Intervene Shiny App | — |
+| 🟦 ヒートマップで見たい | Morpheus | — | TCC-GUI / iDEP |
+| 🧬 遺伝子リストを解釈したい | — | g:Profiler / Metascape | — |
+| 🗺 ゲノム上のデータを見たい | — | UCSC Genome Browser | WashU Epigenome Browser |
+| 📈 発現変動を解析・可視化 | — | — | TCC-GUI / iDEP |
+
+※ 本日は初級（★☆☆〜★★★）を中心に紹介。中級・上級は最後にまとめてリンク紹介。
 
 ---
-## 生命科学系の文献に頻出する英語表現を高速に検索する
-### 逐次PubMed表現検索 inMeXes (インメクセズ)
-生命科学系の文献（PubMedに含まれるタイトルとアブストラクト）に頻出する英語表現を、1文字の入力ごとに高速に再検索します。検索結果から用例や関連情報を容易に取得することができます。
-(https://docman.dbcls.jp/im/)
-#### 利用例
-
-* 英語で論文や記事を書く際に、よく使われる表現を確認する。
-* 興味のある遺伝子や蛋白質に関する記述としてよく使われる表現を検索する。
----
-![fig5](https://raw.githubusercontent.com/hiromasaono/training/master/images/180612_05.png)
+# 📊 分布・統計を見たい
+## BoxPlotR ★☆☆
+- http://shiny.chemgrid.org/boxplotr/
 
 ---
+## BoxPlotR でできること
+- 箱ひげ図・バイオリン図・ビースワームを選択して作成
+- 統計検定（t検定・Wilcoxon等）の自動実行と有意差バー描画
+- SVG / PDF で高解像度出力
 
-![fig6](https://raw.githubusercontent.com/hiromasaono/training/master/images/180612_06.png)
+### 操作フロー
+1. 数値データをタブ区切りで貼り付け
+2. プロットタイプを選択（Box / Violin / Beeswarm）
+3. 色・フォント・検定を調整
+4. PNG / SVG でダウンロード
 
----
-#### inMeXesの特徴
-##### 綴りに自信がなくても目的の英語表現を容易に検索
-
-* 4文字以上の入力で、生命科学系の文献で実際に用いられている表現をPubMed/MEDLINEデータベースにおける頻度順に表示します。
-
-##### 一度のクリックでマッチした表現の用例が閲覧可能
-
-* 用例は、「[ライフサイエンス辞書プロジェクト](https://lsd-project.jp/cgi-bin/lsdproj/ejlookup04.pl)」が提供している共起表現リストや、「[生命科学DB横断検索](https://dbsearch.biosciencedbc.jp)」の文献・データベースリストなどで確認できます。
-
-##### 検索結果をブックマークしてほかの利用者と共有できる
-
-* 一度検索した表現の用例は、結果を再現しやすくするためにURLを生成することができ検索結果のブックマークや共有に便利です。
----
-
-
-#### 統合TVで使いかたを学ぶ
-
-統合TV「[inMeXesを使って文献に頻出する英語表現や関連語を高速に検索する 2018](https://togotv.dbcls.jp/20180126.html)」DOI: 10.7875/togotv.2018.026
+- インストール・登録不要。Excelの数値を貼るだけで論文品質の図が作れる。
+- 統合TV: [BoxPlotR を使って箱ひげ図を作成する](https://togotv.dbcls.jp/20211109.html)
 
 ---
+## BoxPlotR — プロットタイプと使い分け
+### プロットタイプ
+- **Box plot**：四分位・中央値・外れ値の確認
+- **Violin plot**：分布の形を直感的に伝えたいとき
+- **Beeswarm**：個々のデータ点も表示したいとき
+- Box + Beeswarm など組み合わせも可
 
-## 生命科学分野の略語・展開形を検索する
-### Allie (アリー): A Search Service for Abbreviation / Long Form
-PubMed（米国立医学図書館が開発・維持している生物医学文献書誌情報データベース）を利用して、文献中に登場する略語とその正式名称の組およびその付随情報を検索します。
-(https://allie.dbcls.jp/)
-#### 利用例
-
-* ある略語について、その正式名称を知る。
-* ある略語が最初に文献に登場した時期を知る。
-* 新たな略語をつくろうとしたとき、その略語がすでに存在しているかどうかを調べる。
-
----
-
-![fig7](https://raw.githubusercontent.com/hiromasaono/training/master/images/180612_07.png)
+### 統計検定
+- t検定・Wilcoxon検定・Kruskal-Wallis等
+- 有意差の星（*）とブラケットを自動描画
 
 ---
-
-![fig8](https://raw.githubusercontent.com/hiromasaono/training/master/images/180612_08.png)
-
----
-
-#### Allieの特徴
-
-* PubMed収録文献のタイトルとアブストラクトに出現する略語とその正式名称の組について、略語と正式名称のいずれか一方、あるいは、正式名称の一部をクエリとする検索ができます。
-* 日本語の対訳がある正式名称については、あわせて表示します。
-* 検索結果の略語もしくは正式名称について、それらが出現する文献情報も取得できます。
-* タイトルあるいはアブストラクト中に共起するほかの略語も検索結果から閲覧できます。
+# 🔵 集合を比較したい
+## Draw Venn Diagram / draw.io ★☆☆
+## Intervene Shiny App ★★☆
 
 ---
+## Draw Venn Diagram / draw.io ★☆☆
+### Draw Venn Diagram
+- http://bioinformatics.psb.ugent.be/webtools/Venn/
+- 最大5セットを比較
+- 各ボックスにリストを貼るだけ
+- 各領域の要素リストをそのまま取得可能
+- 統合TV: [ウェブツール Draw Venn Diagram を利用してベン図を作成する](https://togotv.dbcls.jp/20180404.html)
 
-#### 統合TVで使いかたを学ぶ
+### draw.io
+- https://app.diagrams.net/
+- 汎用図形作成ツール（ベン図テンプレートあり）
+- フローチャート・概念図にも応用可
+- Google Driveと連携して保存
+- 統合TV: [draw.io を使ってベン図とフローチャートを作成する](https://togotv.dbcls.jp/20210822.html)
 
-* 統合TV「[Allieを使って略語の正式名称を検索する 2017](https://togotv.dbcls.jp/20171025.html)」DOI: 10.7875/togotv.2017.104
-
----
-
-## 類似したテキストの差分を検索・表示する
-### テキスト比較ツール difff《ﾃﾞｭﾌﾌ》
-https://difff.jp/
-
----
-![fig9](https://raw.githubusercontent.com/hiromasaono/training/master/images/180612_09.png)
-
----
-#### difff(ﾃﾞｭﾌﾌ)の特徴
-* diffコマンドを使った比較結果をWeb上に表示するツール
-* テキストボックスに比較したい文章をコピペしてボタンを押すだけで2つの文章でどこが変更されたのか差分の確認ができる
-* 日本語のテキストも対応
-* Word文章はもちろんソースコード、 遺伝子リストなどの比較も可能
-* [某問題で活躍](http://www.itmedia.co.jp/news/articles/1403/12/news121.html)
+- **使い分け**：「リストの重複を数えたい」→ Venn Diagram ／ 「自由に図を描きたい」→ draw.io
 
 ---
-#### 統合TVで使いかたを学ぶ
-* 統合TV「[difff《デュフフ》を使って文章の変更箇所を調べる](https://togotv.dbcls.jp/20130828.html)」DOI: 10.7875/togotv.2013.056
+## Intervene Shiny App ★★☆
+- https://asntech.shinyapps.io/intervene/
+### できること（3種類のプロットを選択可能）
+- **ベン図**（最大6セット）
+- **UpSetプロット**（セットが多いときの比較に最適）
+- **ペアワイズヒートマップ**（Jaccard係数等でセット間類似度を可視化）
+- SVG / PDF / PNG でエクスポート
+
+### 入力
+- テキストファイル（1行1要素）を複数アップロード
+- 各ファイル = 1セット（条件A・B・C…の遺伝子リスト等）
+- 統合TV: [Intervene Shiny App を使ってベン図やUpSetプロット、ヒートマップを作成する](https://togotv.dbcls.jp/20220226.html)
 
 ---
+## ベン図 vs UpSetプロット — 使い分け
+### ベン図
+- 視覚的に直感的
+- 2〜3セットが最適
+- 4セット以上になると見づらい
+- 重複の「大小感」が伝わりやすい
 
-## 文献管理ツール
-### Paperpile
-[Paperpile](https://paperpile.com/)は、[Google Docs](https://www.google.com/intl/ja_jp/docs/about/)との連携に重点を置いたWebベースの商用文献管理ソフトウェアです。(30日間無料で試用でき、その後は月額2.99ドルと気軽に利用できます。) Paperpileの一部はGoogle Chromeの拡張機能として実装されています。
+### UpSetプロット
+- 4セット以上になったとき有効
+- 各交差集合のサイズを棒グラフで明示
+- 論文での採用例が増加中
+- 3セット以下でも使える
 
-(https://paperpile.com/)
-#### 利用例
-
-* 学術出版社のウェブサイトやPubMed、Google Scholar、arXivなどのデータベースやプレプリントサーバからデータをワンタッチでインポートすることができます。
-  
-* Google Docsとの連携機能を利用して、収集した論文の書誌情報をもとに引用リストを様々なフォーマットで作成することができます。
-
----
-#### 統合TVで使いかたを学ぶ
-* 統合TV「[Paperpileを使って文献情報の管理や引用文献リストを作成する](https://togotv.dbcls.jp/20200716.html)」DOI: 10.7875/togotv.2020.069
-* 統合TV「[文献管理ツールを使って研究の進展とアウトプットを加速する @ AJACSオンライン11](https://togotv.dbcls.jp/20220806.html)」DOI: 10.7875/togotv.2022.080
-  * 検索で見つけた論文を管理し、さらに、自らの論文執筆において参考文献のリストを作成するまでの一連の作業を行えるようになり、また、そのために、自らのニーズに合わせたソフトウェアを選択できるようになることを目的として、PubMedのAlert・RSS機能の活用やSlackとの連携による効率的な情報収集方法をはじめ、代表的な文献管理ツールとしてMendeley、Zotero、Paperpileの紹介や具体的な利用方法などについて紹介
+- セットが4つ以上になったら **UpSetプロット** を検討しよう
 
 ---
-## イラスト
-
-* [Bioicons](https://bioicons.com/)
-* [Servier Medical Art](https://smart.servier.com/)
-* [NIH BioART](https://bioart.niaid.nih.gov)
-* [BioRender](https://www.biorender.com/) ([統合TV](https://togotv.dbcls.jp/20190402.html))
-* [draw.io](https://app.diagrams.net) ([統合TV](https://togotv.dbcls.jp/20210822.html))
- 
+# 🟦 行列データをヒートマップで見たい
+## Morpheus ★☆☆
+## TCC-GUI / iDEP ★★★（「発現変動解析」のセクションでも紹介）
 
 ---
+## Morpheus ★☆☆
+- https://software.broadinstitute.org/morpheus/
+### できること
+- 行列データをヒートマップで可視化
+- 行・列のクラスタリング（階層的・k-means等）
+- カラースケールの自由なカスタマイズ
+- フィルタリング・ソート
+- SVG / PNG / PDF でエクスポート
 
+### 入力
+- タブ区切り（.txt）またはGCT形式
+- ブラウザに直接コピペも可
+
+- 統合TV: [Morpheus を使って、様々な行列データをヒートマップで表示しウェブブラウザでデータ解析をする](https://togotv.dbcls.jp/20181109.html)
+
+---
+## Morpheus — 操作フローとこんなデータに使える
+### 操作フロー
+1. ファイルを開く（タブ区切り貼り付けも可）
+2. カラースケール設定（連続 / 発散 / 離散）
+3. 行・列を並べ替え（クラスタリング / ソート）
+4. エクスポート（SVG / PNG / PDF）
+
+### こんなデータに使える
+- 遺伝子 × サンプルの発現量行列（RNA-seq）
+- タンパク質 × 条件のスコア表
+- サンプル間・遺伝子間の相関行列
+- OTUテーブル（メタゲノム）
+
+### より高度なヒートマップへ（中〜上級）
+- **R: pheatmap** — カスタマイズ自由度が高い
+- **R: ComplexHeatmap** — 複雑なアノテーション付き
+
+---
+# 🧬 遺伝子リストを解釈したい
+## g:Profiler ★★☆
+## Metascape ★★☆
+
+---
+## エンリッチメント解析とは
+- 遺伝子リスト（例：DEG 300遺伝子）→ データベースと照合（GO / KEGG / Reactome…）→ 統計的に富化した機能カテゴリを抽出 → バーチャート・バブルチャート等で可視化
+- 「発現が上がった遺伝子群」の生物学的文脈を掴むための解析。個々の遺伝子を調べる代わりに、遺伝子セット全体の傾向を統計的に見る。
+
+### 主なデータベース
+- **Gene Ontology (GO)**：Biological Process / MF / CC
+- **KEGG Pathway**：代謝・シグナル経路
+- **Reactome**：ヒトを中心とした経路情報
+
+### 注意点
+- バックグラウンド（全遺伝子）の設定が重要
+- 多重検定補正（FDR）の確認を忘れずに
+- 結果の解釈には生物学的文脈が必要
+
+---
+## g:Profiler ★★☆
+- https://biit.cs.ut.ee/gprofiler/gost
+### できること
+- GO / KEGG / Reactome / TF / miRNA 等へのエンリッチメント
+- 200種以上の生物種に対応（ヒト・マウス・酵母等）
+- 遺伝子IDの相互変換機能あり（g:Convert）
+- バーチャート・マンハッタンプロットで可視化
+- R / Python API も提供（登録不要）
+
+### 入力
+- 遺伝子名・Ensembl ID・UniProt ID等をテキストボックスに貼り付け
+- 登録不要で即使える
+
+- 統合TV: [g:Profiler を使ってエンリッチメント解析と ID 変換を行う](https://togotv.dbcls.jp/20200127.html)
+
+---
+## Metascape ★★☆
+- https://metascape.org/
+### できること
+- エンリッチメント解析 ＋ 多彩な可視化を自動生成
+- Enrichment Heatmap（複数リストの比較）
+- PPIネットワーク（タンパク質間相互作用）
+- 複数リストを同時解析して比較できる
+- 解析レポートをまとめてダウンロード
+
+### 入力
+- 遺伝子リストをテキストボックスに貼り付け
+- ユーザー登録が必要（無料）
+
+- 統合TV: [Metascapeを使って遺伝子リストの生物学的解釈をする](https://togotv.dbcls.jp/20240910.html)
+
+---
+## g:Profiler vs Metascape — 使い分け
+### g:Profiler を選ぶとき
+- 手早くエンリッチメントを確認したい
+- 200種以上の生物種に対応が必要
+- 遺伝子IDを変換したい（g:Convert）
+- R / Python から呼び出したい
+- 登録不要ですぐ使いたい
+
+### Metascape を選ぶとき
+- 複数の遺伝子リストを同時に比較したい
+- PPIネットワークもセットで出したい
+- 解析レポートをまとめて報告したい
+- ヒートマップ形式で複数条件を比較したい
+
+- どちらも「まず試す」のがおすすめ。出力形式の好みや目的に合わせて選ぼう。
+
+---
+# 🗺 ゲノム上のデータを見たい
+## UCSC Genome Browser ★★☆
+## WashU Epigenome Browser ★★★
+
+---
+## UCSC Genome Browser ★★☆
+- https://genome.ucsc.edu/
+### できること
+- ゲノム配列・遺伝子アノテーションの参照（UCSC・Ensembl・RefSeq等）
+- dbSNP・ClinVar・GTEx など膨大なデータを重ねて表示
+- 自前データ（BED / WIG / VCF等）をカスタムトラックとして追加
+- Table Browserで配列・アノテーションデータを取得
+- Data Integratorで複数トラックの交点を抽出
+
+- 「この遺伝子周辺にどんな情報があるか」を素早く確認するゲノムブラウザの定番。
+- 統合TV: [UCSC Genome Browser](https://togotv.dbcls.jp/result.html?type=manual&page=1&query=UCSC) 関連動画多数
+
+---
+## WashU Epigenome Browser ★★★
+- https://epigenomegateway.wustl.edu/
+### できること
+- ChIP-seq・ATAC-seq・Hi-C等のエピゲノムデータを重ねて可視化
+- ENCODE・Roadmap Epigenomics等の公共データをすぐ参照可能
+- 自前のBigWig / BAMファイルをURL指定で追加
+- ヒートマップトラック・3Dゲノム（Hi-C）の可視化にも対応
+- セッションURLの共有機能
+
+- ChIP-seq / ATAC-seq の解析後の確認に。BigWigファイルのURLがあればすぐ使える。
+- 統合TV: [WashU Epigenome Browser でゲノムとエピゲノムを可視化する](https://togotv.dbcls.jp/20250416.html)
+
+---
+## ゲノムブラウザ — 比較・使い分け
+
+| ツール | 難易度 | 得意な用途 | 特徴 |
+|:--|:--|:--|:--|
+| UCSC | ★★☆ | 汎用・アノテーション確認 | 登録データが膨大。まずUCSCを見る習慣を |
+| WashU | ★★★ | エピゲノム・Hi-C可視化 | 複数エピゲノムトラックを並べて比較するのが得意 |
+| IGV（中級） | ★★☆〜 | ローカルBAM / VCF確認 | 手元のマッピングデータをすぐ確認。デスクトップ版・ウェブ版あり |
+| JBrowse2（中級） | ★★☆〜 | 自前データベース構築 | ローカルに立ち上げられる軽量ゲノムブラウザ |
+
+- 「まず遺伝子を見る」→ UCSC ／ 「ChIP/ATACを重ねたい」→ WashU ／ 「自分のBAMを見たい」→ IGV
+
+---
+# 📈 発現変動を解析・可視化したい
+## TCC-GUI ★★★
+## iDEP ★★★
+※ コマンドライン不要、ブラウザから実行可能
+
+---
+## TCC-GUI ★★★
+- https://ds.dbcls.jp/TCC-GUI
+### できること
+- RNA-seqカウントデータの正規化・差次発現解析
+- DESeq2 / edgeR / TCC-R を選択実行
+- MAプロット・Volcanoプロット・ヒートマップを自動生成
+- DEGリストをCSVで出力
+
+### 入力
+- 遺伝子 × サンプルのカウント行列（タブ区切り）
+- サンプルのグループ情報（2群〜多群）
+
+### 操作フロー
+1. カウント行列をアップロード → 2. グループ設定・解析手法を選択 → 3. MAプロット・Volcanoプロット生成 → 4. DEGリストをエクスポート
+
+- 統合TV: [TCC-GUI を使って RNA-seq データの解析をブラウザで行う](https://togotv.dbcls.jp/20191122.html)
+
+---
+## iDEP ★★★
+- http://bioinformatics.sdstate.edu/idep/
+### できること（TCC-GUIより多機能）
+- DEG解析 ＋ PCA ＋ クラスタリング ＋ パスウェイ解析まで一気通貫
+- Volcano / MA / Heatmap / PCA / UMAP など多彩な出力
+- GSEA・エンリッチメント解析も内蔵
+- 60種以上の生物種に対応
+
+### TCC-GUI vs iDEP — 使い分け
+- **TCC-GUI** を選ぶとき：DEG解析だけを手早くやりたい。DBCLSサーバーで安定して使いたい。
+- **iDEP** を選ぶとき：PCA・パスウェイ解析もまとめてやりたい。多機能なツールを探索したい。
+
+- 統合TV: [iDEPを使ってウェブブラウザ上でRNA-seqデータ解析を行う](https://togotv.dbcls.jp/20200118.html)
+
+---
+## 中級・上級ツール — 参考リンク
+
+| レベル | 目的 | ツール | 統合TV |
+|:--|:--|:--|:--|
+| 中級 | ネットワーク・パスウェイ可視化 | Cytoscape | [20150707](https://togotv.dbcls.jp/20150707.html) |
+| 中級 | マッピングデータの確認 | IGV | [20240704](https://togotv.dbcls.jp/20240704.html) |
+| 中級 | パスウェイ図の描画・WikiPathways公開 | PathVisio | [20260121](https://togotv.dbcls.jp/20260121.html) |
+| 中級 | ゲノムブラウザ（自前データ構築） | JBrowse2 | [20250106](https://togotv.dbcls.jp/20250106.html) |
+| 上級 | 統計グラフ全般（R） | ggplot2 | [コース一覧](https://togotv.dbcls.jp/courses.html) |
+| 上級 | 複雑なヒートマップ（R） | ComplexHeatmap / pheatmap | [コース一覧](https://togotv.dbcls.jp/courses.html) |
+| 上級 | エンリッチメント解析・可視化（R） | clusterProfiler / enrichplot | [コース一覧](https://togotv.dbcls.jp/courses.html) |
+| 上級 | シングルセル解析・UMAP（R/Python） | Seurat / scanpy | [20250129](https://togotv.dbcls.jp/20250129.html) |
+
+---
+# 全体のまとめ
+
+## ツール選びの指針
+| 目的 | ★☆☆ 貼るだけ | ★★☆ リスト・設定あり | ★★★ 解析データ必要 |
+|:--|:--|:--|:--|
+| 📊 分布・統計 | BoxPlotR | — | — |
+| 🔵 集合比較 | Venn / draw.io | Intervene | — |
+| 🟦 ヒートマップ | Morpheus | — | TCC-GUI / iDEP |
+| 🧬 遺伝子リスト解釈 | — | g:Profiler / Metascape | — |
+| 🗺 ゲノム上のデータ | — | UCSC | WashU |
+| 📈 発現変動解析 | — | — | TCC-GUI / iDEP |
+
+---
 # 全体のまとめ
 - 生命科学分野におけるデータ駆動型研究の重要性
   - 日々増加・進化するDBやツールを効果的に活用する能力が必須
   - 統合TVなどのリソースを活用し、常に最新の知識・スキルを習得
   - 正面からしか見られなかったものが横や後ろやナナメから見ることができるのがデータ駆動型研究のいいところ
-  - ｢バイオインフォマティクス｣も顕微鏡 や 実験試薬 などと同じ「道具(ツール)」
-  - 便利な「道具」を知って、その使い方が分かれば、あとはみなさん自身の情報分析力と想像力の勝負
+  - ｢バイオインフォマティクス｣も顕微鏡 や 実験試薬 などと同じ「道具(ツール)」
+  - 便利な「道具」を知って、その使い方が分かれば、あとはみなさん自身の情報分析力と想像力の勝負
+- **まずウェブツールから試してみよう**
+  - インストール不要のツールで感覚をつかんでから、より高度なツールへ段階的に
+  - 統合TV（[togotv.dbcls.jp](https://togotv.dbcls.jp)）で使い方動画を確認できます


### PR DESCRIPTION
The Marp markdown file previously contained TUAT (東京農工大学) lecture
content (Ⅱ-7/Ⅱ-8 course) instead of the NMS/NVLU seminar content.

Changes:
- Replace TUAT-specific title, date, and overview with NMS/NVLU seminar info
- Part 1: Add TogoTV introduction content matching part1_togotv.html
- Part 2: Replace inMeXes/Allie/difff text tools with data visualization
  tools (BoxPlotR, Venn Diagram, Morpheus, g:Profiler, Metascape,
  UCSC/WashU Genome Browsers, TCC-GUI, iDEP) matching part2_visualization.html
- Add tool comparison tables and usage guidance
- Add intermediate/advanced tools reference table

https://claude.ai/code/session_01KB1XrSr9BPPyr7nH6zay65